### PR TITLE
Improve canvas controls and responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=800, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>HTML5 Game</title>
     <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
     <canvas id="gameCanvas" width="800" height="600"></canvas>
     <script src="scripts/main.js"></script>
-</body>
-</html>
+</body></html>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # HTML5 Game
 
-**Version:** 006
+**Version:** 007
 A modern HTML5 3D terrain engine starter.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -180,8 +180,18 @@ function shadeColor(hex, percent) {
 
 // --- Keyboard Controls ---
 let keyState = {};
-document.addEventListener('keydown', e => { keyState[e.code] = true; });
-document.addEventListener('keyup', e => { keyState[e.code] = false; });
+document.addEventListener('keydown', e => {
+  keyState[e.code] = true;
+  if (['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Equal', 'Minus'].includes(e.code)) {
+    e.preventDefault();
+  }
+});
+document.addEventListener('keyup', e => {
+  keyState[e.code] = false;
+});
+window.addEventListener('blur', () => {
+  keyState = {};
+});
 
 function handleCameraInput() {
   // Left/right: rotate flying direction (and camera view)

--- a/styles/main.css
+++ b/styles/main.css
@@ -5,10 +5,16 @@ body {
     overflow: hidden;
 }
 
+html, body {
+    height: 100%;
+}
+
 canvas {
     display: block;
     margin: 0 auto;
     background: #222;
     border: none;
     border-radius: 0;
-}
+    width: 100%;
+    height: 100%;
+    touch-action: none;}


### PR DESCRIPTION
## Summary
- make canvas fill the screen and disable touch scrolling
- prevent default page scrolling when using keyboard controls
- clear held keys when the window loses focus
- fix viewport meta tag for mobile
- update Readme version

## Testing
- `node --check scripts/main.js`

------
https://chatgpt.com/codex/tasks/task_e_686d913b9470832ab05e680968ad3476