### PR TITLE
Fix blank page due to duplicate shadeColor

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -196,14 +196,6 @@ function drawSlopedTerrain(ctx) {
   ctx.restore();
 }
 
-// --- Color Shading ---
-function shadeColor(hex, percent) {
-  let num = parseInt(hex.replace('#',''),16);
-  let r = Math.min(255, Math.floor(((num >> 16) & 0xFF) * percent));
-  let g = Math.min(255, Math.floor(((num >> 8) & 0xFF) * percent));
-  let b = Math.min(255, Math.floor((num & 0xFF) * percent));
-  return `rgb(${r},${g},${b})`;
-}
 
 // --- Keyboard Controls ---
 let keyState = {};


### PR DESCRIPTION
## Summary
- remove duplicate `shadeColor` definition
- rely on `shadeColor` from `utils.mjs`

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6877a1bd0c84832aa7ff861b7f4f8a5c