### PR TITLE
Flatten terrain height range

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # HTML5 Game
 
-**Version:** 011
+**Version:** 012
 A modern HTML5 3D terrain engine starter.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-// Game version: 011
+// Game version: 012
 import { hash, computeHeight, getColor, shadeColor } from './utils.mjs';
 
 const canvas = document.getElementById('gameCanvas');

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3,12 +3,18 @@ export function hash(x, y) {
 }
 
 export function computeHeight(x, y) {
-  return Math.floor(
-    2.2 +
-    2 * Math.sin(x * 0.25 + y * 0.17) +
-    1.5 * Math.cos(x * 0.19 - y * 0.23) +
-    0.8 * hash(x, y)
-  );
+  // Generate a gentle rolling heightmap. The combination of sine, cosine
+  // and hashed noise produces terrain variation while keeping the results
+  // within the 0-3 range requested by the user.
+  const noise =
+    0.8 * Math.sin(x * 0.3 + y * 0.17) +
+    0.6 * Math.cos(x * 0.27 - y * 0.19) +
+    // Center the hash around 0 then scale it to keep the final height low
+    (hash(x, y) - 0.5) * 0.8;
+
+  const h = Math.floor(1.5 + noise);
+  // Clamp to ensure the terrain never exceeds the [0,3] bounds
+  return Math.min(3, Math.max(0, h));
 }
 
 let colorMap = {};

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
 test('computeHeight deterministic values', () => {
-  assert.equal(computeHeight(0,0), 3);
-  assert.equal(computeHeight(1,1), 5);
-  assert.equal(computeHeight(-1,-1), 3);
+  assert.equal(computeHeight(0,0), 1);
+  assert.equal(computeHeight(1,1), 2);
+  assert.equal(computeHeight(-1,-1), 2);
 });
 
 test('shadeColor darkens red at 50%', () => {


### PR DESCRIPTION
## Summary
- limit generated terrain heights to 0-3 for a flatter world
- bump game version to 012
- update tests for new deterministic height values

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6877b8449f94832a84a1ee4d95ec8631