### PR TITLE
Fix color shading for short hex

### DIFF
--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -32,7 +32,12 @@ export function getColor(x, y) {
 }
 
 export function shadeColor(hex, percent) {
-  let num = parseInt(hex.replace('#',''),16);
+  let h = hex.replace('#','');
+  // Expand 3-digit hex colors to 6-digit so bit operations work correctly
+  if (h.length === 3) {
+    h = h.split('').map(c => c + c).join('');
+  }
+  let num = parseInt(h, 16);
   let r = Math.min(255, Math.floor(((num >> 16) & 0xFF) * percent));
   let g = Math.min(255, Math.floor(((num >> 8) & 0xFF) * percent));
   let b = Math.min(255, Math.floor((num & 0xFF) * percent));

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -12,6 +12,11 @@ test('shadeColor darkens red at 50%', () => {
   assert.equal(shadeColor('#ff0000', 0.5), 'rgb(127,0,0)');
 });
 
+test('shadeColor handles 3-digit hex colors', () => {
+  assert.equal(shadeColor('#0f0', 1), 'rgb(0,255,0)');
+  assert.equal(shadeColor('#0f0', 0.5), 'rgb(0,127,0)');
+});
+
 test('getColor caching and determinism', () => {
   const c1 = getColor(2,3);
   const c2 = getColor(2,3);


### PR DESCRIPTION
## Summary
- ensure shadeColor handles 3-digit hex colors by expanding them
- add regression test for short hex colors

## Testing
- `node tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6877bcafb134832a81ee58d2c1a727b3