### PR TITLE
Render filled grid for flat terrain

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -140,13 +140,15 @@ function computeTileData(x, y) {
 }
 
 function drawTile(ctx, tile) {
+  ctx.fillStyle = tile.color;
   ctx.beginPath();
   ctx.moveTo(tile.pts[0][0], tile.pts[0][1]);
   ctx.lineTo(tile.pts[1][0], tile.pts[1][1]);
   ctx.lineTo(tile.pts[2][0], tile.pts[2][1]);
   ctx.lineTo(tile.pts[3][0], tile.pts[3][1]);
   ctx.closePath();
-  ctx.strokeStyle = "#0f0";
+  ctx.fill();
+  ctx.strokeStyle = "#111a";
   ctx.stroke();
 }
 


### PR DESCRIPTION
## Summary
- fill each tile with color when drawing
- keep flat height function

## Testing
- `node tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6877c31a5928832aa91620fec82c6c64