### PR TITLE
Revert to earlier working build

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HTML5 Game v014</title>
+    <title>HTML5 Game</title>
     <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # HTML5 Game
 
-**Version:** 014
+**Version:** 010
 A modern HTML5 3D terrain engine starter.

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3,9 +3,12 @@ export function hash(x, y) {
 }
 
 export function computeHeight(x, y) {
-  // For this simplified build the terrain is completely flat at height 0.
-  // We keep the function for API compatibility but ignore the input.
-  return 0;
+  return Math.floor(
+    2.2 +
+    2 * Math.sin(x * 0.25 + y * 0.17) +
+    1.5 * Math.cos(x * 0.19 - y * 0.23) +
+    0.8 * hash(x, y)
+  );
 }
 
 let colorMap = {};
@@ -23,12 +26,7 @@ export function getColor(x, y) {
 }
 
 export function shadeColor(hex, percent) {
-  let h = hex.replace('#','');
-  // Expand 3-digit hex colors to 6-digit so bit operations work correctly
-  if (h.length === 3) {
-    h = h.split('').map(c => c + c).join('');
-  }
-  let num = parseInt(h, 16);
+  let num = parseInt(hex.replace('#',''),16);
   let r = Math.min(255, Math.floor(((num >> 16) & 0xFF) * percent));
   let g = Math.min(255, Math.floor(((num >> 8) & 0xFF) * percent));
   let b = Math.min(255, Math.floor((num & 0xFF) * percent));

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -3,18 +3,13 @@ import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
 test('computeHeight deterministic values', () => {
-  assert.equal(computeHeight(0,0), 0);
-  assert.equal(computeHeight(1,1), 0);
-  assert.equal(computeHeight(-1,-1), 0);
+  assert.equal(computeHeight(0,0), 3);
+  assert.equal(computeHeight(1,1), 5);
+  assert.equal(computeHeight(-1,-1), 3);
 });
 
 test('shadeColor darkens red at 50%', () => {
   assert.equal(shadeColor('#ff0000', 0.5), 'rgb(127,0,0)');
-});
-
-test('shadeColor handles 3-digit hex colors', () => {
-  assert.equal(shadeColor('#0f0', 1), 'rgb(0,255,0)');
-  assert.equal(shadeColor('#0f0', 0.5), 'rgb(0,127,0)');
 });
 
 test('getColor caching and determinism', () => {


### PR DESCRIPTION
## Summary
- roll back the project to version 010
- restore earlier computeHeight and tile rendering parameters
- keep camera movement disabled and use mobile orientation controls

## Testing
- `node tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6878c3d4a250832a86d58f772cbfc166