### PR TITLE
Restore procedural terrain heights

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -9,7 +9,7 @@ debugEl.style.display = 'block';
 
 // --- Engine Parameters ---
 const tileSize = 32;
-const tilesInView = 72;
+const tilesInView = 36;
 // Perspective parameters
 let fieldOfView = Math.PI / 2.4; // ~75° vertical FOV
 let focal = (canvas.height / 2) / Math.tan(fieldOfView / 2);
@@ -37,7 +37,7 @@ function getHeight(x, y) {
 
 // --- Camera State ---
 let camera = {
-  x: 0, y: 0, altitude: 10,
+  x: 0, y: 0, altitude: 7.5,
   speed: 0.14,
   yaw: Math.PI / 4,       // where the camera looks
   flyYaw: Math.PI / 4,    // direction of forward movement

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3,9 +3,18 @@ export function hash(x, y) {
 }
 
 export function computeHeight(x, y) {
-  // For this simplified build the terrain is completely flat at height 0.
-  // We keep the function for API compatibility but ignore the input.
-  return 0;
+  // Generate a gentle rolling heightmap. The combination of sine, cosine
+  // and hashed noise produces terrain variation while keeping the results
+  // within a low [0,3] height range.
+  const noise =
+    0.8 * Math.sin(x * 0.3 + y * 0.17) +
+    0.6 * Math.cos(x * 0.27 - y * 0.19) +
+    // Center the hash around 0 then scale it to keep the final height low
+    (hash(x, y) - 0.5) * 0.8;
+
+  const h = Math.floor(1.5 + noise);
+  // Clamp to ensure the terrain never exceeds the [0,3] bounds
+  return Math.min(3, Math.max(0, h));
 }
 
 let colorMap = {};

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
 test('computeHeight deterministic values', () => {
-  assert.equal(computeHeight(0,0), 0);
-  assert.equal(computeHeight(1,1), 0);
-  assert.equal(computeHeight(-1,-1), 0);
+  assert.equal(computeHeight(0,0), 1);
+  assert.equal(computeHeight(1,1), 2);
+  assert.equal(computeHeight(-1,-1), 2);
 });
 
 test('shadeColor darkens red at 50%', () => {


### PR DESCRIPTION
## Summary
- bring back procedural computeHeight for height variation
- adjust camera altitude and view radius
- update tests for new height calculations

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6878c75bb6a4832a820da3a9073fc67a