### PR TITLE
Reduce terrain height and fix visibility

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -101,16 +101,18 @@ function updateDebugInfo() {
 function isTileVisible(x, y) {
   const centerX = x + 0.5;
   const centerY = y + 0.5;
+  const centerH = computeHeight(centerX, centerY);
   const dx = centerX - camera.x;
   const dy = centerY - camera.y;
   const distSq = dx * dx + dy * dy;
   if (distSq === 0) return true;
   const dot = (dx * cosYaw + dy * sinYaw) / Math.sqrt(distSq);
   if (dot < cosHalfHFOV) return false;
-  const proj = project3D(centerX, centerY, camera.altitude);
+  const proj = project3D(centerX, centerY, centerH);
   if (!proj) return false;
   const [sx, sy] = proj;
-  return !(sx < -canvas.width || sx > canvas.width || sy < -canvas.height || sy > canvas.height);
+  const margin = 64;
+  return !(sx < -margin || sx > canvas.width + margin || sy < -margin || sy > canvas.height + margin);
 }
 
 // --- Terrain Drawing ---

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3,12 +3,16 @@ export function hash(x, y) {
 }
 
 export function computeHeight(x, y) {
-  return Math.floor(
-    2.2 +
-    2 * Math.sin(x * 0.25 + y * 0.17) +
-    1.5 * Math.cos(x * 0.19 - y * 0.23) +
-    0.8 * hash(x, y)
-  );
+  // Generate a gentle rolling heightmap.  The combination of sine, cosine and
+  // hashed noise keeps variation interesting while clamping the range to 0-3 so
+  // the terrain never rises too high above the camera.
+  const noise =
+    0.8 * Math.sin(x * 0.3 + y * 0.17) +
+    0.6 * Math.cos(x * 0.27 - y * 0.19) +
+    (hash(x, y) - 0.5) * 0.8;
+
+  const h = Math.floor(1.5 + noise);
+  return Math.min(3, Math.max(0, h));
 }
 
 let colorMap = {};

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -3,9 +3,9 @@ import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
 test('computeHeight deterministic values', () => {
-  assert.equal(computeHeight(0,0), 3);
-  assert.equal(computeHeight(1,1), 5);
-  assert.equal(computeHeight(-1,-1), 3);
+  assert.equal(computeHeight(0,0), 1);
+  assert.equal(computeHeight(1,1), 2);
+  assert.equal(computeHeight(-1,-1), 2);
 });
 
 test('shadeColor darkens red at 50%', () => {


### PR DESCRIPTION
## Summary
- lower the overall terrain height so hills aren't as tall
- improve tile visibility checks by projecting with tile height and adding margin
- update tests for new height range

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6878dea46b20832a9f4cbd81ed27bdc5