### PR TITLE
v0.1.3: restore auto flying terrain

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HTML5 Game v012</title>
+    <title>HTML5 Game v013</title>
     <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # HTML5 Game
 
-**Version:** 012
+**Version:** 013
 A modern HTML5 3D terrain engine starter.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-// Game version: 012
+// Game version: 013
 import { hash, computeHeight, getColor, shadeColor, resetColorMap } from './utils.mjs';
 
 const canvas = document.getElementById('gameCanvas');
@@ -37,8 +37,8 @@ function getHeight(x, y) {
 
 // --- Camera State ---
 let camera = {
-  // Start two meters above the ground at the world origin
-  x: 0, y: 0, altitude: 2,
+  // Camera starts high above the ground and continuously moves forward
+  x: 0, y: 0, altitude: 7.5,
   speed: 0.14,
   yaw: Math.PI / 4,       // where the camera looks
   flyYaw: Math.PI / 4,    // direction of forward movement
@@ -92,7 +92,9 @@ function project3D(x, y, h) {
 
 // --- Camera Update ---
 function updateCamera() {
-  // Camera movement disabled for mobile orientation control
+  // Always move forward in the direction of flight
+  camera.x += sinFlyYaw * camera.speed;
+  camera.y += cosFlyYaw * camera.speed;
 }
 
 function updateDebugInfo() {
@@ -195,11 +197,10 @@ function drawSky(ctx) {
 }
 
 function getVerticalOffset() {
-  // Place the horizon at the vertical center when looking straight ahead
-  // and move it upward as the camera tilts down. This keeps the ground
-  // aligned with the device orientation and a real-world floor at z=0.
-  const start = 0.5; // pitch = 0 -> horizon halfway up the screen
-  const end = 0.1;   // looking straight down -> horizon near the top
+  // Keep the horizon low enough that the camera appears above the terrain.
+  // When tilting down, shift it slightly higher to maintain perspective.
+  const start = 0.78; // looking almost straight ahead
+  const end = 0.5;    // looking straight down
   const t = Math.min(1, Math.max(0, (camera.pitch - minPitch) / (maxPitch - minPitch)));
   return canvas.height * (start - (start - end) * t);
 }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -2,11 +2,13 @@ export function hash(x, y) {
   return Math.abs(Math.sin(x * 127.1 + y * 311.7) * 43758.5453) % 1;
 }
 
-export function computeHeight(_x, _y) {
-  // Flat plane at z=0 for all coordinates to represent a real world floor
-  // aligned with the horizon. This simplifies the projection logic so the
-  // virtual grid matches the physical ground level.
-  return 0;
+export function computeHeight(x, y) {
+  return Math.floor(
+    2.2 +
+    2 * Math.sin(x * 0.25 + y * 0.17) +
+    1.5 * Math.cos(x * 0.19 - y * 0.23) +
+    0.8 * hash(x, y)
+  );
 }
 
 let colorMap = {};

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -2,10 +2,10 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
-test('computeHeight returns flat ground', () => {
-  assert.equal(computeHeight(0,0), 0);
-  assert.equal(computeHeight(1,1), 0);
-  assert.equal(computeHeight(-1,-1), 0);
+test('computeHeight deterministic values', () => {
+  assert.equal(computeHeight(0,0), 3);
+  assert.equal(computeHeight(1,1), 5);
+  assert.equal(computeHeight(-1,-1), 3);
 });
 
 test('shadeColor darkens red at 50%', () => {


### PR DESCRIPTION
## Summary
- bring back forward camera motion
- revert flat ground to original rolling terrain
- restore earlier horizon placement
- bump version to 013

## Testing
- `node --test tests/utils.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687902654b84832a88839234666551c0