### PR TITLE
Flatten terrain

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HTML5 Game v013</title>
+    <title>HTML5 Game v014</title>
     <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # HTML5 Game
 
-**Version:** 013
+**Version:** 014
 A modern HTML5 3D terrain engine starter.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-// Game version: 013
+// Game version: 014
 import { hash, computeHeight, getColor, shadeColor, resetColorMap } from './utils.mjs';
 
 const canvas = document.getElementById('gameCanvas');

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3,11 +3,13 @@ export function hash(x, y) {
 }
 
 export function computeHeight(x, y) {
+  // Produce gentler hills by reducing the amplitude of the
+  // sine/cosine components and pseudo-random noise.
   return Math.floor(
     2.2 +
-    2 * Math.sin(x * 0.25 + y * 0.17) +
-    1.5 * Math.cos(x * 0.19 - y * 0.23) +
-    0.8 * hash(x, y)
+    0.5 * Math.sin(x * 0.25 + y * 0.17) +
+    0.4 * Math.cos(x * 0.19 - y * 0.23) +
+    0.3 * hash(x, y)
   );
 }
 

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -3,9 +3,10 @@ import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
 test('computeHeight deterministic values', () => {
-  assert.equal(computeHeight(0,0), 3);
-  assert.equal(computeHeight(1,1), 5);
-  assert.equal(computeHeight(-1,-1), 3);
+  // With a flatter terrain profile the expected heights are lower
+  assert.equal(computeHeight(0,0), 2);
+  assert.equal(computeHeight(1,1), 3);
+  assert.equal(computeHeight(-1,-1), 2);
 });
 
 test('shadeColor darkens red at 50%', () => {


### PR DESCRIPTION
## Summary
- make height map less hilly
- update tests for new height ranges
- bump version to v014

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687905dedc40832abb2e12cddb6058f2