### PR TITLE
Fix rolling terrain computation

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HTML5 Game v014</title>
+    <title>HTML5 Game v015</title>
     <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
 # HTML5 Game
 
-**Version:** 014
+**Version:** 015
 A modern HTML5 3D terrain engine starter.

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,4 +1,4 @@
-// Game version: 014
+// Game version: 015
 import { hash, computeHeight, getColor, shadeColor, resetColorMap } from './utils.mjs';
 
 const canvas = document.getElementById('gameCanvas');

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -3,14 +3,16 @@ export function hash(x, y) {
 }
 
 export function computeHeight(x, y) {
-  // Produce gentler hills by reducing the amplitude of the
-  // sine/cosine components and pseudo-random noise.
-  return Math.floor(
-    2.2 +
-    0.5 * Math.sin(x * 0.25 + y * 0.17) +
-    0.4 * Math.cos(x * 0.19 - y * 0.23) +
-    0.3 * hash(x, y)
-  );
+  // Generate a rolling heightmap that stays roughly within the range 0-3 so
+  // the terrain never rises too high. Using both sine/cosine waves and some
+  // pseudo-random noise gives a natural looking surface.
+  const noise =
+    0.8 * Math.sin(x * 0.3 + y * 0.17) +
+    0.6 * Math.cos(x * 0.27 - y * 0.19) +
+    (hash(x, y) - 0.5) * 0.8;
+
+  const h = Math.floor(1.5 + noise);
+  return Math.min(3, Math.max(0, h));
 }
 
 let colorMap = {};

--- a/tests/utils.test.mjs
+++ b/tests/utils.test.mjs
@@ -3,9 +3,8 @@ import assert from 'node:assert/strict';
 import { computeHeight, shadeColor, getColor, resetColorMap } from '../scripts/utils.mjs';
 
 test('computeHeight deterministic values', () => {
-  // With a flatter terrain profile the expected heights are lower
-  assert.equal(computeHeight(0,0), 2);
-  assert.equal(computeHeight(1,1), 3);
+  assert.equal(computeHeight(0,0), 1);
+  assert.equal(computeHeight(1,1), 2);
   assert.equal(computeHeight(-1,-1), 2);
 });
 


### PR DESCRIPTION
## Summary
- tune the terrain height algorithm for smoother hills
- adjust expected height values in tests
- bump version to v015

## Testing
- `node tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68792bff91e8832aa133f4c6511e4bd1