### PR TITLE
Change raised floor color to bright blue

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,8 +43,9 @@
       floorGrid.material=floorMat;
       scene.add(floorGrid);
 
-      const raisedFloor=new THREE.GridHelper(floorSize,floorDiv,0xff8800,0x884400);
+      const raisedFloor=new THREE.GridHelper(floorSize,floorDiv,0x0000ff,0x0000ff);
       raisedFloor.material=floorMat.clone();
+      raisedFloor.material.color.set(0x0000ff);
       raisedFloor.position.y=GRID_SPACING*3;
       scene.add(raisedFloor);
 


### PR DESCRIPTION
## Summary
- make the raised floor grid bright blue instead of orange

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687a26b961d0832aa489f2061c7d8304