### PR TITLE
Add animated water surface

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
   <button id="calibrateBtn" style="display:none;top:60px;left:20px;position:absolute;padding:10px 20px;font-family:sans-serif;font-size:16px;">Calibrate</button>
   <script>
     let scene,camera,renderer,wallGrids,verticalLines;
+    let waterGeom,waterMesh;
     let orientationOffsetQuat=new THREE.Quaternion();
     let lastQuat=new THREE.Quaternion();
     let offsetInitialized=false;
@@ -62,6 +63,7 @@
 
       createVerticalLines();
       createHorizontalLines();
+      createWaterSurface();
       window.addEventListener('resize',onResize);
     }
 
@@ -108,6 +110,17 @@
       scene.add(horizontalLines);
     }
 
+    function createWaterSurface(){
+      const size=ROOM_SIZE;
+      const segments=50;
+      waterGeom=new THREE.PlaneGeometry(size,size,segments,segments);
+      waterGeom.rotateX(-Math.PI/2);
+      const mat=new THREE.MeshPhongMaterial({color:0x0044ff,transparent:true,opacity:0.6,side:THREE.DoubleSide});
+      waterMesh=new THREE.Mesh(waterGeom,mat);
+      waterMesh.position.y=-0.01;
+      scene.add(waterMesh);
+    }
+
     function onResize(){
       camera.aspect=window.innerWidth/window.innerHeight;
       camera.updateProjectionMatrix();
@@ -117,6 +130,19 @@
     function calibrateOrientation(){
       orientationOffsetQuat.copy(lastQuat);
       offsetInitialized=true;
+    }
+
+    function updateWaterSurface(time){
+      if(!waterGeom) return;
+      const pos=waterGeom.attributes.position;
+      for(let i=0;i<pos.count;i++){
+        const x=pos.getX(i);
+        const z=pos.getZ(i);
+        const y=Math.sin(x*0.5+time)*0.2+Math.cos(z*0.7+time*1.3)*0.2;
+        pos.setY(i,y);
+      }
+      pos.needsUpdate=true;
+      waterGeom.computeVertexNormals();
     }
 
     function handleOrientation(e){
@@ -153,6 +179,8 @@
 
     function animate(){
       requestAnimationFrame(animate);
+      const time=performance.now()*0.001;
+      updateWaterSurface(time);
       renderer.render(scene,camera);
     }
 


### PR DESCRIPTION
## Summary
- create a water surface plane
- animate the plane each frame using sinusoidal waves

## Testing
- `node tests/utils.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687a2f0c4b08832abc93014c5659fdb2