### PR TITLE
Animate water grid lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -110,16 +110,35 @@
       scene.add(horizontalLines);
     }
 
-    function createWaterSurface(){
-      const size=ROOM_SIZE;
-      const segments=50;
-      waterGeom=new THREE.PlaneGeometry(size,size,segments,segments);
-      waterGeom.rotateX(-Math.PI/2);
-      const mat=new THREE.MeshPhongMaterial({color:0x0044ff,transparent:true,opacity:0.6,side:THREE.DoubleSide});
-      waterMesh=new THREE.Mesh(waterGeom,mat);
-      waterMesh.position.y=-0.01;
-      scene.add(waterMesh);
-    }
+      function createWaterSurface(){
+        const size=ROOM_SIZE;
+        const segments=50;
+        const half=size/2;
+        const step=size/segments;
+        const vertices=[];
+        for(let i=0;i<=segments;i++){
+          const z=-half+i*step;
+          for(let j=0;j<segments;j++){
+            const x0=-half+j*step;
+            const x1=x0+step;
+            vertices.push(x0,0,z,x1,0,z);
+          }
+        }
+        for(let j=0;j<=segments;j++){
+          const x=-half+j*step;
+          for(let i=0;i<segments;i++){
+            const z0=-half+i*step;
+            const z1=z0+step;
+            vertices.push(x,0,z0,x,0,z1);
+          }
+        }
+        waterGeom=new THREE.BufferGeometry();
+        waterGeom.setAttribute('position',new THREE.Float32BufferAttribute(vertices,3));
+        const mat=new THREE.LineBasicMaterial({color:0x0044ff,transparent:true,opacity:0.6,depthWrite:false});
+        waterMesh=new THREE.LineSegments(waterGeom,mat);
+        waterMesh.position.y=-0.01;
+        scene.add(waterMesh);
+      }
 
     function onResize(){
       camera.aspect=window.innerWidth/window.innerHeight;
@@ -132,18 +151,17 @@
       offsetInitialized=true;
     }
 
-    function updateWaterSurface(time){
-      if(!waterGeom) return;
-      const pos=waterGeom.attributes.position;
-      for(let i=0;i<pos.count;i++){
-        const x=pos.getX(i);
-        const z=pos.getZ(i);
-        const y=Math.sin(x*0.5+time)*0.2+Math.cos(z*0.7+time*1.3)*0.2;
-        pos.setY(i,y);
+      function updateWaterSurface(time){
+        if(!waterGeom) return;
+        const pos=waterGeom.attributes.position;
+        for(let i=0;i<pos.count;i++){
+          const x=pos.getX(i);
+          const z=pos.getZ(i);
+          const y=Math.sin(x*0.5+time)*0.2+Math.cos(z*0.7+time*1.3)*0.2;
+          pos.setY(i,y);
+        }
+        pos.needsUpdate=true;
       }
-      pos.needsUpdate=true;
-      waterGeom.computeVertexNormals();
-    }
 
     function handleOrientation(e){
       const raw={alpha:e.alpha||0,beta:e.beta||0,gamma:e.gamma||0};


### PR DESCRIPTION
## Summary
- replace water mesh with animated grid line geometry
- update the water surface animation to modify line vertices

## Testing
- `node --test tests/utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_687a3179ec00832abb67c4838bb704ba