### PR TITLE
Add animated wireframe background

### DIFF
--- a/game.html
+++ b/game.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GAME v023</title>
+  <title>GAME v033blocks</title>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <style>
     body,html{margin:0;padding:0;overflow:hidden;background:#000;}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Welcome to the Game</title>
+  <title>Welcome to the Game v033blocks</title>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
   <style>
     body {
       margin: 0;
@@ -16,6 +17,21 @@
       background: linear-gradient(135deg, #1e3c72, #2a5298);
       color: #fff;
       text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+    #bg {
+      position: absolute;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+      filter: blur(2px);
+    }
+    main {
+      position: relative;
+      z-index: 1;
     }
     h1 {
       font-size: 3rem;
@@ -37,10 +53,49 @@
   </style>
 </head>
 <body>
+  <canvas id="bg"></canvas>
   <main>
     <h1>Welcome to the Game</h1>
     <p>Prepare yourself for an immersive 3D experience.</p>
     <a class="play-button" href="game.html">Play Now</a>
   </main>
+  <script>
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 100);
+    camera.position.set(0, 5, 12);
+    const renderer = new THREE.WebGLRenderer({ canvas: document.getElementById('bg'), antialias: true, alpha: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(window.devicePixelRatio);
+
+    const group = new THREE.Group();
+    const size = 10;
+    for (let x = -size; x <= size; x += 2) {
+      for (let z = -size; z <= size; z += 2) {
+        const geom = new THREE.BoxGeometry(1.8, 0.2, 1.8);
+        const edges = new THREE.EdgesGeometry(geom);
+        const line = new THREE.LineSegments(edges, new THREE.LineBasicMaterial({ color: 0xff8800, transparent: true, opacity: 0.5 }));
+        line.position.set(x, 0, z);
+        group.add(line);
+      }
+    }
+    scene.add(group);
+
+    function onResize() {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    }
+    window.addEventListener('resize', onResize);
+
+    function animate(time) {
+      requestAnimationFrame(animate);
+      group.rotation.y = time * 0.0002;
+      group.children.forEach((c, i) => {
+        c.position.y = 0.4 * Math.sin(time * 0.001 + i);
+      });
+      renderer.render(scene, camera);
+    }
+    animate();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enhance landing page with animated wireframe canvas background
- include Three.js on the landing page
- update HTML titles to version v033blocks

## Testing
- `node --test tests/utils.test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_687a800cb558832aa319a26238cdbbae