### PR TITLE
Replace grid-room with surreal walker scene and keep gyroscope/navigation

### DIFF
--- a/game.html
+++ b/game.html
@@ -3,443 +3,596 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>GAME v023</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <title>Surreal Walker // v1.2.1</title>
   <style>
-    body,html{margin:0;padding:0;overflow:hidden;background:#000;}
-    #sceneCanvas{display:block;width:100vw;height:100vh;}
-    #permissionBtn{position:absolute;top:20px;left:20px;padding:10px 20px;font-family:sans-serif;font-size:16px;}
-    .nav-arrows{position:absolute;top:20px;right:20px;display:flex;gap:12px;z-index:5;}
-    .nav-arrows a{width:44px;height:44px;border-radius:50%;display:grid;place-items:center;text-decoration:none;color:#0ff;font-family:sans-serif;font-weight:700;font-size:20px;border:1px solid rgba(0,255,255,0.4);background:rgba(0,0,0,0.55);backdrop-filter:blur(8px);box-shadow:0 0 18px rgba(0,255,255,0.25);transition:transform 0.2s ease,box-shadow 0.2s ease,border-color 0.2s ease;}
-    .nav-arrows a:hover,.nav-arrows a:focus-visible{transform:translateY(-1px) scale(1.02);border-color:rgba(0,255,255,0.7);box-shadow:0 0 22px rgba(0,255,255,0.45);outline:none;}
+    body {
+      margin: 0;
+      overflow: hidden;
+      background-color: #000;
+    }
+    canvas {
+      display: block;
+    }
+    #overlay {
+      position: absolute;
+      bottom: 20px;
+      left: 20px;
+      color: #00ffff;
+      font-family: 'Courier New', monospace;
+      font-size: 14px;
+      font-weight: bold;
+      opacity: 0.9;
+      pointer-events: none;
+      line-height: 1.5;
+      text-shadow: 2px 2px 0px #000;
+      background: rgba(0, 10, 30, 0.7);
+      padding: 15px;
+      border-left: 4px solid #00ffff;
+    }
+    #permissionBtn,
+    #calibrateBtn {
+      position: absolute;
+      top: 20px;
+      left: 20px;
+      padding: 10px 20px;
+      font-family: sans-serif;
+      font-size: 16px;
+      z-index: 6;
+    }
+    #calibrateBtn {
+      top: 60px;
+    }
+    .nav-arrows {
+      position: absolute;
+      top: 20px;
+      right: 20px;
+      display: flex;
+      gap: 12px;
+      z-index: 5;
+    }
+    .nav-arrows a {
+      width: 44px;
+      height: 44px;
+      border-radius: 50%;
+      display: grid;
+      place-items: center;
+      text-decoration: none;
+      color: #0ff;
+      font-family: sans-serif;
+      font-weight: 700;
+      font-size: 20px;
+      border: 1px solid rgba(0, 255, 255, 0.4);
+      background: rgba(0, 0, 0, 0.55);
+      backdrop-filter: blur(8px);
+      box-shadow: 0 0 18px rgba(0, 255, 255, 0.25);
+      transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    }
+    .nav-arrows a:hover,
+    .nav-arrows a:focus-visible {
+      transform: translateY(-1px) scale(1.02);
+      border-color: rgba(0, 255, 255, 0.7);
+      box-shadow: 0 0 22px rgba(0, 255, 255, 0.45);
+      outline: none;
+    }
   </style>
 </head>
 <body>
-  <canvas id="sceneCanvas"></canvas>
+  <div id="overlay">
+    SYSTEM: COSMOS_ENGINE_V12.1<br>
+    SHADER_STATUS: COMPILED<br>
+    NOISE_DIMENSION: 3D_ENABLED<br>
+    STATUS: DREAMING
+  </div>
   <button id="permissionBtn" style="display:none;">Enable Motion</button>
-  <button id="calibrateBtn" style="display:none;top:60px;left:20px;position:absolute;padding:10px 20px;font-family:sans-serif;font-size:16px;">Calibrate</button>
+  <button id="calibrateBtn" style="display:none;">Calibrate</button>
   <div class="nav-arrows" aria-label="Page navigation">
     <a class="arrow-left" href="index.html" aria-label="Back to hub">&#8592;</a>
     <a class="arrow-right" href="terrain.html" aria-label="Next experience">&#8594;</a>
   </div>
-  <script>
-    let scene,camera,renderer,wallGrids,verticalLines,horizontalLines,floorGrid,raisedFloor;
-    let waterGeom,waterMesh;
-    let orientationOffsetQuat=new THREE.Quaternion();
-    let lastQuat=new THREE.Quaternion();
-    let offsetInitialized=false;
-    let keyboardState={};
-    let explosions=[];
-    let fallingTiles=[];
-    let lastTime=performance.now()*0.001;
-    const GRAVITY=9.8;
-    const raycaster=new THREE.Raycaster();
-    const clickPlane=new THREE.Plane(new THREE.Vector3(0,1,0),0);
-    const ROOM_SIZE=30;
-    const GRID_SPACING=10;
-    const moveDir=new THREE.Vector3();
-    function initScene(){
-      scene=new THREE.Scene();
-      scene.background=new THREE.Color(0x000000);
-      camera=new THREE.PerspectiveCamera(75,window.innerWidth/window.innerHeight,0.1,1000);
-      camera.position.set(0,1.5,5);
-      renderer=new THREE.WebGLRenderer({canvas:document.getElementById('sceneCanvas'),antialias:true});
-      renderer.setSize(window.innerWidth,window.innerHeight);
-      renderer.setPixelRatio(window.devicePixelRatio);
 
-      scene.add(new THREE.AmbientLight(0x404040));
-      const light=new THREE.PointLight(0xffffff,1,100);
-      light.position.set(0,5,0);
-      scene.add(light);
-      const sun=new THREE.DirectionalLight(0xffffff,0.8);
-      sun.position.set(5,10,2);
-      scene.add(sun);
-
-      const floorSize=ROOM_SIZE;
-      const floorDiv=30;
-      const floorMat=new THREE.LineBasicMaterial({color:0xff8800,opacity:0.4,transparent:true});
-      floorGrid=new THREE.GridHelper(floorSize,floorDiv,0xff8800,0x884400);
-      floorGrid.material=floorMat;
-      scene.add(floorGrid);
-
-      const platformHeight=GRID_SPACING*0.11;
-      const tileCount=10;
-      const tileSize=floorSize/tileCount;
-      raisedFloor=new THREE.Group();
-      for(let i=0;i<tileCount;i++){
-        for(let j=0;j<tileCount;j++){
-          const geo=new THREE.BoxGeometry(tileSize,platformHeight,tileSize);
-          const mat=new THREE.MeshBasicMaterial({color:0x555555});
-          const tile=new THREE.Mesh(geo,mat);
-          const edges=new THREE.EdgesGeometry(geo);
-          const lineMat=new THREE.LineBasicMaterial({color:0xffffff});
-          const line=new THREE.LineSegments(edges,lineMat);
-          tile.add(line);
-          tile.position.set(
-            -floorSize/2+tileSize/2+i*tileSize,
-            platformHeight/2,
-            -floorSize/2+tileSize/2+j*tileSize
-          );
-          tile.userData.baseColor=0x555555;
-          tile.userData.alive=true;
-          tile.userData.falling=false;
-          tile.userData.height=platformHeight;
-          raisedFloor.add(tile);
-        }
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/"
       }
-      raisedFloor.position.y=GRID_SPACING*0.33;
-      scene.add(raisedFloor);
-
-      wallGrids=new THREE.Group();
-      const wallSize=ROOM_SIZE;
-      const wallDiv=30;
-      const wallMat=new THREE.LineBasicMaterial({color:0x00ffff,opacity:0.2,transparent:true});
-      const front=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);front.rotation.x=Math.PI/2;front.position.z=-wallSize/2;front.position.y=wallSize/2;front.material=wallMat.clone();wallGrids.add(front);
-      const back=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);back.rotation.x=Math.PI/2;back.position.z=wallSize/2;back.position.y=wallSize/2;back.material=wallMat.clone();wallGrids.add(back);
-      const left=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);left.rotation.z=Math.PI/2;left.position.x=-wallSize/2;left.position.y=wallSize/2;left.material=wallMat.clone();wallGrids.add(left);
-      const right=new THREE.GridHelper(wallSize,wallDiv,0x00ffff,0x008888);right.rotation.z=Math.PI/2;right.position.x=wallSize/2;right.position.y=wallSize/2;right.material=wallMat.clone();wallGrids.add(right);
-      const ceiling=new THREE.GridHelper(floorSize,floorDiv,0x00ffff,0x008888);ceiling.position.y=wallSize;ceiling.material=floorMat.clone();ceiling.material.opacity=0.2;wallGrids.add(ceiling);
-      scene.add(wallGrids);
-
-      createVerticalLines();
-      createHorizontalLines();
-      createWaterSurface();
-      window.addEventListener('resize',onResize);
-      window.addEventListener('orientationchange',onResize);
-      renderer.domElement.addEventListener('click',handleClick);
     }
+  </script>
 
-    function createVerticalLines(){
-      const gridExtent=ROOM_SIZE/2;
-      const height=ROOM_SIZE;
-      const step=GRID_SPACING;
-      const offset=step/2;
-      const vertices=[];
-      for(let x=-gridExtent+offset;x<=gridExtent;x+=step){
-        for(let z=-gridExtent+offset;z<=gridExtent;z+=step){
-          vertices.push(x,0,z);
-          vertices.push(x,height,z);
-        }
-      }
-      const geo=new THREE.BufferGeometry();
-      geo.setAttribute('position',new THREE.Float32BufferAttribute(vertices,3));
-      const mat=new THREE.LineBasicMaterial({color:0xff00ff,opacity:0.6,transparent:true,depthWrite:false});
-      verticalLines=new THREE.LineSegments(geo,mat);
-      verticalLines.renderOrder=1;
-      scene.add(verticalLines);
-    }
+  <script type="module">
+    import * as THREE from 'three';
+    import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+    import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+    import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
 
-    function createHorizontalLines(){
-      const gridExtent=ROOM_SIZE/2;
-      const step=GRID_SPACING;
-      const levels=[step/2, ROOM_SIZE/2, ROOM_SIZE-step/2];
-      const vertices=[];
-      for(const y of levels){
-        for(let x=-gridExtent;x<=gridExtent;x+=step){
-          vertices.push(x,y,-gridExtent);
-          vertices.push(x,y,gridExtent);
-        }
-        for(let z=-gridExtent;z<=gridExtent;z+=step){
-          vertices.push(-gridExtent,y,z);
-          vertices.push(gridExtent,y,z);
-        }
-      }
-      const geo=new THREE.BufferGeometry();
-      geo.setAttribute('position',new THREE.Float32BufferAttribute(vertices,3));
-      const mat=new THREE.LineBasicMaterial({color:0xff00ff,opacity:0.4,transparent:true,depthWrite:false});
-      horizontalLines=new THREE.LineSegments(geo,mat);
-      horizontalLines.renderOrder=1;
-      scene.add(horizontalLines);
-    }
+    let scene;
+    let camera;
+    let renderer;
+    let composer;
+    let terrainUniforms;
+    let planetUniforms;
+    let cloudUniforms;
+    let planet;
+    let ring;
+    let moon1;
+    let moon2;
+    let cloudGroup;
 
-      function createWaterSurface(){
-        const size=ROOM_SIZE;
-        const segments=50;
-        waterGeom=new THREE.PlaneGeometry(size,size,segments,segments);
-        waterGeom.rotateX(-Math.PI/2);
-        const colors=new Float32Array(waterGeom.attributes.position.count*3);
-        const baseColor=new THREE.Color(0x888888);
-        for(let i=0;i<waterGeom.attributes.position.count;i++){
-          colors[i*3]=baseColor.r;
-          colors[i*3+1]=baseColor.g;
-          colors[i*3+2]=baseColor.b;
-        }
-        waterGeom.setAttribute('color',new THREE.Float32BufferAttribute(colors,3));
-        const mat=new THREE.MeshBasicMaterial({vertexColors:true,transparent:true,opacity:0.6});
-        waterMesh=new THREE.Mesh(waterGeom,mat);
-        waterMesh.position.y=-0.01;
-        waterMesh.userData.baseColor=colors.slice();
-        scene.add(waterMesh);
+    const orientationOffsetQuat = new THREE.Quaternion();
+    const lastQuat = new THREE.Quaternion();
+    const gyroQuat = new THREE.Quaternion();
+    let offsetInitialized = false;
+    let gyroEnabled = false;
+
+    const snoiseFunction = `
+      vec3 permute(vec3 x) { return mod(((x*34.0)+1.0)*x, 289.0); }
+      vec4 permute(vec4 x) { return mod(((x*34.0)+1.0)*x, 289.0); }
+      vec4 taylorInvSqrt(vec4 r) { return 1.79284291400159 - 0.85373472095314 * r; }
+
+      float snoise(vec2 v){
+        const vec4 C = vec4(0.211324865405187, 0.366025403784439,
+                -0.577350269189626, 0.024390243902439);
+        vec2 i  = floor(v + dot(v, C.yy) );
+        vec2 x0 = v - i + dot(i, C.xx);
+        vec2 i1;
+        i1 = (x0.x > x0.y) ? vec2(1.0, 0.0) : vec2(0.0, 1.0);
+        vec4 x12 = x0.xyxy + C.xxzz;
+        x12.xy -= i1;
+        i = mod(i, 289.0);
+        vec3 p = permute( permute( i.y + vec3(0.0, i1.y, 1.0 ))
+        + i.x + vec3(0.0, i1.x, 1.0 ));
+        vec3 m = max(0.5 - vec3(dot(x0,x0), dot(x12.xy,x12.xy), dot(x12.zw,x12.zw)), 0.0);
+        m = m*m ;
+        m = m*m ;
+        vec3 x = 2.0 * fract(p * C.www) - 1.0;
+        vec3 h = abs(x) - 0.5;
+        vec3 ox = floor(x + 0.5);
+        vec3 a0 = x - ox;
+        m *= 1.79284291400159 - 0.85373472095314 * ( a0*a0 + h*h );
+        vec3 g;
+        g.x  = a0.x  * x0.x  + h.x  * x0.y;
+        g.yz = a0.yz * x12.xz + h.yz * x12.yw;
+        return 130.0 * dot(m, g);
       }
 
-    function onResize(){
-      camera.aspect=window.innerWidth/window.innerHeight;
-      camera.updateProjectionMatrix();
-      renderer.setSize(window.innerWidth,window.innerHeight);
-    }
-
-    function calibrateOrientation(){
-      orientationOffsetQuat.copy(lastQuat);
-      offsetInitialized=true;
-    }
-
-      function updateWaterSurface(time){
-        if(!waterGeom) return;
-        const pos=waterGeom.attributes.position;
-        for(let i=0;i<pos.count;i++){
-          const x=pos.getX(i);
-          const z=pos.getZ(i);
-          const y=Math.sin(x*0.5+time)*0.6+Math.cos(z*0.7+time*1.3)*0.6;
-          pos.setY(i,y);
-        }
-        pos.needsUpdate=true;
-        waterGeom.computeVertexNormals();
+      float snoise(vec3 v){
+        const vec2  C = vec2(1.0/6.0, 1.0/3.0) ;
+        const vec4  D = vec4(0.0, 0.5, 1.0, 2.0);
+        vec3 i  = floor(v + dot(v, C.yyy) );
+        vec3 x0 = v - i + dot(i, C.xxx) ;
+        vec3 g = step(x0.yzx, x0.xyz);
+        vec3 l = 1.0 - g;
+        vec3 i1 = min( g.xyz, l.zxy );
+        vec3 i2 = max( g.xyz, l.zxy );
+        vec3 x1 = x0 - i1 + 1.0 * C.xxx;
+        vec3 x2 = x0 - i2 + 2.0 * C.xxx;
+        vec3 x3 = x0 - 1.0 + 3.0 * C.xxx;
+        i = mod(i, 289.0 );
+        vec4 p = permute( permute( permute(
+                    i.z + vec4(0.0, i1.z, i2.z, 1.0 ))
+                + i.y + vec4(0.0, i1.y, i2.y, 1.0 ))
+                + i.x + vec4(0.0, i1.x, i2.x, 1.0 ));
+        float n_ = 1.0/7.0;
+        vec3  ns = n_ * D.wyz - D.xzx;
+        vec4 j = p - 49.0 * floor(p * ns.z * ns.z);
+        vec4 x_ = floor(j * ns.z);
+        vec4 y_ = floor(j - 7.0 * x_ );
+        vec4 x = x_ *ns.x + ns.yyyy;
+        vec4 y = y_ *ns.x + ns.yyyy;
+        vec4 h = 1.0 - abs(x) - abs(y);
+        vec4 b0 = vec4( x.xy, y.xy );
+        vec4 b1 = vec4( x.zw, y.zw );
+        vec4 s0 = floor(b0)*2.0 + 1.0;
+        vec4 s1 = floor(b1)*2.0 + 1.0;
+        vec4 sh = -step(h, vec4(0.0));
+        vec4 a0 = b0.xzyw + s0.xzyw*sh.xxyy ;
+        vec4 a1 = b1.xzyw + s1.xzyw*sh.zzww ;
+        vec3 p0 = vec3(a0.xy,h.x);
+        vec3 p1 = vec3(a0.zw,h.y);
+        vec3 p2 = vec3(a1.xy,h.z);
+        vec3 p3 = vec3(a1.zw,h.w);
+        vec4 norm = taylorInvSqrt(vec4(dot(p0,p0), dot(p1,p1), dot(p2, p2), dot(p3,p3)));
+        p0 *= norm.x;
+        p1 *= norm.y;
+        p2 *= norm.z;
+        p3 *= norm.w;
+        vec4 m = max(0.6 - vec4(dot(x0,x0), dot(x1,x1), dot(x2,x2), dot(x3,x3)), 0.0);
+        m = m * m;
+        return 42.0 * dot( m*m, vec4( dot(p0,x0), dot(p1,x1),
+                                        dot(p2,x2), dot(p3,x3) ) );
       }
+    `;
 
-      function updateRaisedFloor(time){
-        if(!raisedFloor) return;
-        const t=(Math.sin(time)+1)/2;
-        const base=GRID_SPACING*0.33;
-        const amp=GRID_SPACING*0.33;
-        raisedFloor.position.y=base+amp*t;
-        const hue=(time*0.2)%1;
-        raisedFloor.children.forEach(tile=>{
-          if(tile.userData.falling) return;
-          tile.material.color.setHSL(hue,1,0.5);
-        });
+    const terrainVertexShader = `
+      varying vec2 vUv;
+      varying float vHeight;
+      varying vec3 vPos;
+      varying float vScrollZ;
+      uniform float uTime;
+      uniform float uSpeed;
+      ${snoiseFunction}
+      void main() {
+        vUv = uv;
+        vec3 pos = position;
+        float scrollZ = pos.z - (uTime * uSpeed);
+        float noiseVal = snoise(vec2(pos.x * 0.02, scrollZ * 0.02));
+        float spikeVal = pow(abs(noiseVal), 2.0);
+        if (noiseVal < 0.0) spikeVal = -spikeVal;
+        float valleyMask = smoothstep(10.0, 50.0, abs(pos.x));
+        float finalHeight = spikeVal * valleyMask * 80.0;
+        pos.y += finalHeight;
+        vHeight = finalHeight;
+        vPos = pos;
+        vScrollZ = scrollZ;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
       }
+    `;
 
-      function updateFallingTiles(delta){
-        for(let i=fallingTiles.length-1;i>=0;i--){
-          const tile=fallingTiles[i];
-          tile.position.addScaledVector(tile.userData.velocity,delta);
-          tile.userData.velocity.y-=GRAVITY*delta;
-          const half=(tile.userData.height||tile.geometry.parameters.height)/2;
-          if(tile.position.y<half){
-            tile.position.y=half;
-            tile.userData.velocity.y*=-0.5;
-            tile.userData.velocity.x*=0.8;
-            tile.userData.velocity.z*=0.8;
-            if(Math.abs(tile.userData.velocity.y)<0.1){
-              tile.userData.velocity.y=0;
-            }
-          }
-          if(tile.position.y<=half && tile.userData.velocity.length()<0.05){
-            fallingTiles.splice(i,1);
-          }
-        }
+    const terrainFragmentShader = `
+      varying vec2 vUv;
+      varying float vHeight;
+      varying vec3 vPos;
+      varying float vScrollZ;
+      uniform float uTime;
+      uniform vec3 uColorA;
+      uniform vec3 uColorB;
+      void main() {
+        float gridSize = 5.0;
+        float lineThickness = 0.03;
+        vec2 gridUV = vec2(vPos.x, vScrollZ) / gridSize;
+        gridUV = fract(gridUV);
+        float gridX = step(1.0 - lineThickness, gridUV.x) + step(gridUV.x, lineThickness);
+        float gridZ = step(1.0 - lineThickness, gridUV.y) + step(gridUV.y, lineThickness);
+        float gridPattern = max(gridX, gridZ);
+        float heightFactor = smoothstep(0.0, 80.0, vHeight);
+        vec3 baseColor = mix(uColorA, uColorB, heightFactor);
+        float pulse = sin(vScrollZ * 0.1 + uTime * 2.0);
+        float pulseLine = smoothstep(0.9, 1.0, pulse);
+        baseColor += vec3(0.5, 0.8, 1.0) * pulseLine * 0.5;
+        vec3 finalColor = mix(vec3(0.01, 0.0, 0.02), baseColor * 2.0, gridPattern);
+        float dist = gl_FragCoord.z / gl_FragCoord.w;
+        float fogFactor = smoothstep(15.0, 160.0, dist);
+        finalColor = mix(finalColor, vec3(0.0), fogFactor);
+        gl_FragColor = vec4(finalColor, 1.0);
       }
+    `;
 
-      function handleKeyDown(e){
-        if(e.code.startsWith('Arrow')) e.preventDefault();
-        keyboardState[e.code]=true;
+    const planetVertexShader = `
+      varying vec2 vUv;
+      varying vec3 vNormal;
+      varying vec3 vViewPosition;
+      void main() {
+        vUv = uv;
+        vNormal = normalize(normalMatrix * normal);
+        vec4 mvPosition = modelViewMatrix * vec4(position, 1.0);
+        vViewPosition = -mvPosition.xyz;
+        gl_Position = projectionMatrix * mvPosition;
       }
+    `;
 
-      function handleKeyUp(e){
-        if(e.code.startsWith('Arrow')) e.preventDefault();
-        keyboardState[e.code]=false;
+    const planetFragmentShader = `
+      varying vec2 vUv;
+      varying vec3 vNormal;
+      varying vec3 vViewPosition;
+      uniform float uTime;
+      ${snoiseFunction}
+      void main() {
+        float y = vUv.y * 10.0;
+        float bands = sin(y + sin(y * 2.0 + uTime * 0.1));
+        float noiseDetail = snoise(vec2(vUv.x * 5.0 + uTime * 0.05, vUv.y * 5.0));
+        vec3 color1 = vec3(0.1, 0.0, 0.3);
+        vec3 color2 = vec3(0.0, 0.8, 0.9);
+        vec3 color3 = vec3(1.0, 0.0, 0.5);
+        vec3 baseColor = mix(color1, color2, bands * 0.5 + 0.5);
+        baseColor = mix(baseColor, color3, noiseDetail * 0.3);
+        vec3 normal = normalize(vNormal);
+        vec3 viewDir = normalize(vViewPosition);
+        float rim = 1.0 - max(dot(viewDir, normal), 0.0);
+        rim = pow(rim, 4.0);
+        vec3 finalColor = baseColor + vec3(0.5, 0.8, 1.0) * rim * 2.0;
+        gl_FragColor = vec4(finalColor, 1.0);
       }
+    `;
 
-      function updateKeyboardControls(delta){
-        const moveSpeed=6;
-        const rotateSpeed=1.5;
-        if(keyboardState['ArrowLeft']) camera.rotation.y+=rotateSpeed*delta;
-        if(keyboardState['ArrowRight']) camera.rotation.y-=rotateSpeed*delta;
-        camera.getWorldDirection(moveDir);
-        moveDir.y=0;
-        moveDir.normalize();
-        if(keyboardState['ArrowUp']) camera.position.addScaledVector(moveDir,moveSpeed*delta);
-        if(keyboardState['ArrowDown']) camera.position.addScaledVector(moveDir,-moveSpeed*delta);
+    const cloudVertexShader = `
+      varying vec2 vUv;
+      varying float vNoise;
+      uniform float uTime;
+      ${snoiseFunction}
+      void main() {
+        vUv = uv;
+        vec3 pos = position;
+        float n = snoise(vec3(pos.x * 0.1, pos.y * 0.1, uTime * 0.2));
+        pos += normal * n * 2.0;
+        vNoise = n;
+        gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
       }
+    `;
 
-      function handleClick(event){
-        const rect=renderer.domElement.getBoundingClientRect();
-        const mouse=new THREE.Vector2(
-          ((event.clientX-rect.left)/rect.width)*2-1,
-          -((event.clientY-rect.top)/rect.height)*2+1
+    const cloudFragmentShader = `
+      varying vec2 vUv;
+      varying float vNoise;
+      void main() {
+        vec3 color = vec3(0.8, 0.9, 1.0);
+        float alpha = 0.4 + vNoise * 0.3;
+        gl_FragColor = vec4(color, alpha);
+      }
+    `;
+
+    function initScene() {
+      scene = new THREE.Scene();
+      const fogColor = new THREE.Color(0x050011);
+      scene.background = fogColor;
+      scene.fog = new THREE.FogExp2(fogColor, 0.012);
+
+      camera = new THREE.PerspectiveCamera(60, window.innerWidth / window.innerHeight, 0.1, 2000);
+      renderer = new THREE.WebGLRenderer({ antialias: false, powerPreference: 'high-performance' });
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+      document.body.appendChild(renderer.domElement);
+
+      const terrainGeo = new THREE.PlaneGeometry(400, 400, 250, 250);
+      terrainGeo.rotateX(-Math.PI / 2);
+      terrainUniforms = {
+        uTime: { value: 0.0 },
+        uSpeed: { value: 5.5 },
+        uColorA: { value: new THREE.Color(0x00ffff) },
+        uColorB: { value: new THREE.Color(0x00aaff) }
+      };
+      const terrainMat = new THREE.ShaderMaterial({
+        vertexShader: terrainVertexShader,
+        fragmentShader: terrainFragmentShader,
+        uniforms: terrainUniforms,
+        side: THREE.DoubleSide
+      });
+      const terrain = new THREE.Mesh(terrainGeo, terrainMat);
+      scene.add(terrain);
+
+      const planetGroup = new THREE.Group();
+      planetGroup.position.set(0, 50, -350);
+      scene.add(planetGroup);
+
+      const planetGeo = new THREE.SphereGeometry(60, 64, 64);
+      planetUniforms = { uTime: { value: 0.0 } };
+      const planetMat = new THREE.ShaderMaterial({
+        vertexShader: planetVertexShader,
+        fragmentShader: planetFragmentShader,
+        uniforms: planetUniforms
+      });
+      planet = new THREE.Mesh(planetGeo, planetMat);
+      planetGroup.add(planet);
+
+      const ringGeo = new THREE.RingGeometry(80, 110, 128);
+      const ringMat = new THREE.MeshBasicMaterial({
+        color: 0xff00cc,
+        side: THREE.DoubleSide,
+        transparent: true,
+        opacity: 0.6,
+        blending: THREE.AdditiveBlending
+      });
+      ring = new THREE.Mesh(ringGeo, ringMat);
+      ring.rotation.x = Math.PI / 2.5;
+      ring.rotation.y = -Math.PI / 8;
+      planetGroup.add(ring);
+
+      const moonGeo = new THREE.SphereGeometry(8, 32, 32);
+      const moonMat1 = new THREE.MeshBasicMaterial({ color: 0xffaa00 });
+      moon1 = new THREE.Mesh(moonGeo, moonMat1);
+      moon1.position.set(100, 30, 20);
+      planetGroup.add(moon1);
+
+      const moonMat2 = new THREE.MeshBasicMaterial({ color: 0x00ffaa });
+      moon2 = new THREE.Mesh(moonGeo, moonMat2);
+      moon2.scale.set(0.6, 0.6, 0.6);
+      moon2.position.set(-120, -20, 50);
+      planetGroup.add(moon2);
+
+      cloudGroup = new THREE.Group();
+      scene.add(cloudGroup);
+      cloudUniforms = { uTime: { value: 0.0 } };
+      const cloudMat = new THREE.ShaderMaterial({
+        vertexShader: cloudVertexShader,
+        fragmentShader: cloudFragmentShader,
+        uniforms: cloudUniforms,
+        transparent: true,
+        side: THREE.FrontSide,
+        blending: THREE.AdditiveBlending,
+        depthWrite: false
+      });
+
+      for (let i = 0; i < 8; i++) {
+        const size = 10 + Math.random() * 15;
+        const cGeo = new THREE.SphereGeometry(size, 32, 32);
+        const cloud = new THREE.Mesh(cGeo, cloudMat);
+        cloud.position.set(
+          (Math.random() - 0.5) * 300,
+          40 + Math.random() * 50,
+          -100 - Math.random() * 200
         );
-        raycaster.setFromCamera(mouse,camera);
-        let point=null;
-        let target=null; // 'water' or 'floor'
-        const intersects=raycaster.intersectObjects([waterMesh,raisedFloor],true);
-        if(intersects.length>0){
-          point=intersects[0].point.clone();
-          const obj=intersects[0].object;
-          if(obj===waterMesh){
-            target='water';
-          }else{
-            target='floor';
-          }
-        }else{
-          point=new THREE.Vector3();
-          raycaster.ray.intersectPlane(clickPlane,point);
-        }
-        const geom=new THREE.BufferGeometry().setFromPoints(Array.from({length:65},(_,i)=>{
-          const a=i/64*Math.PI*2;
-          return new THREE.Vector3(Math.cos(a),0,Math.sin(a));
-        }));
-        const mat=new THREE.LineBasicMaterial({color:0xffff00,transparent:true});
-        const ring=new THREE.LineLoop(geom,mat);
-        ring.rotation.x=-Math.PI/2;
-        ring.position.copy(point);
-        const start=performance.now()*0.001;
-        scene.add(ring);
-        explosions.push({ring,center:point.clone(),start,affected:new Set(),target});
+        cloudGroup.add(cloud);
       }
 
-      function updateExplosions(time){
-        resetDistortion();
-        for(let i=explosions.length-1;i>=0;i--){
-          const exp=explosions[i];
-          const t=time-exp.start;
-          exp.ring.scale.setScalar(1+t*5);
-          exp.ring.material.opacity=Math.max(0,1-t*0.5);
-          applyDistortion(exp.center,t,exp);
-          if(t>2){
-            scene.remove(exp.ring);
-            exp.ring.geometry.dispose();
-            exp.ring.material.dispose();
-            exp.affected.forEach(tile=>{
-              const worldPos=tile.getWorldPosition(new THREE.Vector3());
-              raisedFloor.remove(tile);
-              tile.position.copy(worldPos);
-              tile.material.color.set(tile.userData.baseColor);
-              tile.userData.alive=false;
-              tile.userData.falling=true;
-              tile.userData.velocity=new THREE.Vector3(
-                (tile.position.x-exp.center.x),
-                4+Math.random()*2,
-                (tile.position.z-exp.center.z)
-              );
-              scene.add(tile);
-              fallingTiles.push(tile);
-            });
-            explosions.splice(i,1);
-          }
-        }
-      }
+      const renderScene = new RenderPass(scene, camera);
+      const bloomPass = new UnrealBloomPass(
+        new THREE.Vector2(window.innerWidth, window.innerHeight),
+        1.5,
+        0.4,
+        0.85
+      );
+      bloomPass.threshold = 0.15;
+      bloomPass.strength = 1.2;
+      bloomPass.radius = 0.7;
 
-      function resetDistortion(){
-        if(waterGeom && waterGeom.userData.base){
-          const pos=waterGeom.attributes.position;
-          const base=waterGeom.userData.base;
-          const colors=waterGeom.attributes.color;
-          const baseCol=waterMesh.userData.baseColor;
-          for(let i=0;i<pos.count;i++){
-            pos.setXYZ(i,base[i*3],base[i*3+1],base[i*3+2]);
-            colors.setXYZ(i,baseCol[i*3],baseCol[i*3+1],baseCol[i*3+2]);
-          }
-          pos.needsUpdate=true;
-          colors.needsUpdate=true;
-        }
-      }
+      composer = new EffectComposer(renderer);
+      composer.addPass(renderScene);
+      composer.addPass(bloomPass);
 
-      function applyDistortion(center,t,exp){
-        const radius=t*5;
-        const floorRadius=Math.min(radius,3); // limit floor effect
-        const strength=Math.max(0,1-t*0.5)*0.5;
-        if((!exp.target || exp.target==='water') && waterGeom){
-          const pos=waterGeom.attributes.position;
-          const colors=waterGeom.attributes.color;
-          if(!waterGeom.userData.base) waterGeom.userData.base=pos.array.slice();
-          if(!waterMesh.userData.baseColor) waterMesh.userData.baseColor=colors.array.slice();
-          const base=waterGeom.userData.base;
-          const baseCol=waterMesh.userData.baseColor;
-          for(let i=0;i<pos.count;i++){
-            const bx=base[i*3];
-            const by=base[i*3+1];
-            const bz=base[i*3+2];
-            const dist=Math.hypot(bx-center.x,bz-center.z);
-            let y=by;
-            if(dist<radius){
-              y+= (radius-dist)/radius*strength;
-              colors.setXYZ(i,1,0,0);
-            }else{
-              colors.setXYZ(i,baseCol[i*3],baseCol[i*3+1],baseCol[i*3+2]);
-            }
-            pos.setXYZ(i,bx,y,bz);
-          }
-          pos.needsUpdate=true;
-          colors.needsUpdate=true;
-          waterGeom.computeVertexNormals();
-        }
-        if((!exp.target || exp.target==='floor') && raisedFloor){
-          const MAX_REMOVALS=5;
-          raisedFloor.children.forEach(tile=>{
-            if(!tile.userData.alive) return;
-            const worldPos=tile.getWorldPosition(new THREE.Vector3());
-            const dist=Math.hypot(worldPos.x-center.x,worldPos.z-center.z);
-            if(dist<floorRadius){
-              tile.material.color.set(0xff0000);
-              if(exp && (exp.affected.has(tile) || exp.affected.size<MAX_REMOVALS)){
-                exp.affected.add(tile);
-              }
-            }else{
-              tile.material.color.set(tile.userData.baseColor);
-            }
-          });
-        }
-      }
+      window.addEventListener('resize', onResize);
+    }
 
-    function handleOrientation(e){
-      const raw={alpha:e.alpha||0,beta:e.beta||0,gamma:e.gamma||0};
-      const r=Math.PI/180;
-      const alpha=raw.alpha*r;
-      const beta=raw.beta*r;
-      const gamma=raw.gamma*r;
-      const orient=(screen.orientation&&typeof screen.orientation.angle==='number')
-        ?THREE.MathUtils.degToRad(screen.orientation.angle)
-        : (typeof window.orientation==='number'?THREE.MathUtils.degToRad(window.orientation):0);
-      const euler=new THREE.Euler();
-      const zee=new THREE.Vector3(0,0,1);
-      const q0=new THREE.Quaternion();
-      const q1=new THREE.Quaternion(-Math.sqrt(0.5),0,0,Math.sqrt(0.5));
-      euler.set(beta,alpha,-gamma,'YXZ');
-      const quaternion=new THREE.Quaternion().setFromEuler(euler);
+    function onResize() {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+      composer.setSize(window.innerWidth, window.innerHeight);
+    }
+
+    function calibrateOrientation() {
+      orientationOffsetQuat.copy(lastQuat);
+      offsetInitialized = true;
+    }
+
+    function handleOrientation(e) {
+      const raw = { alpha: e.alpha || 0, beta: e.beta || 0, gamma: e.gamma || 0 };
+      const r = Math.PI / 180;
+      const alpha = raw.alpha * r;
+      const beta = raw.beta * r;
+      const gamma = raw.gamma * r;
+      const orient = (screen.orientation && typeof screen.orientation.angle === 'number')
+        ? THREE.MathUtils.degToRad(screen.orientation.angle)
+        : (typeof window.orientation === 'number' ? THREE.MathUtils.degToRad(window.orientation) : 0);
+      const euler = new THREE.Euler();
+      const zee = new THREE.Vector3(0, 0, 1);
+      const q0 = new THREE.Quaternion();
+      const q1 = new THREE.Quaternion(-Math.sqrt(0.5), 0, 0, Math.sqrt(0.5));
+      euler.set(beta, alpha, -gamma, 'YXZ');
+      const quaternion = new THREE.Quaternion().setFromEuler(euler);
       quaternion.multiply(q1);
-      quaternion.multiply(q0.setFromAxisAngle(zee,-orient));
+      quaternion.multiply(q0.setFromAxisAngle(zee, -orient));
       lastQuat.copy(quaternion);
-      if(!offsetInitialized){orientationOffsetQuat.copy(quaternion);offsetInitialized=true;}
-      const calibrated=quaternion.clone().premultiply(orientationOffsetQuat.clone().invert());
-      camera.quaternion.slerp(calibrated,0.2);
+      if (!offsetInitialized) {
+        orientationOffsetQuat.copy(quaternion);
+        offsetInitialized = true;
+      }
+      gyroQuat.copy(quaternion.clone().premultiply(orientationOffsetQuat.clone().invert()));
+      gyroEnabled = true;
     }
 
-    function startOrientation(){
-      window.addEventListener('deviceorientation',handleOrientation);
-      document.getElementById('calibrateBtn').style.display='block';
+    function startOrientation() {
+      window.addEventListener('deviceorientation', handleOrientation);
+      document.getElementById('calibrateBtn').style.display = 'block';
     }
 
-    function requestPermission(){
-      if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){
-        DeviceOrientationEvent.requestPermission().then(state=>{if(state==='granted'){startOrientation();document.getElementById('permissionBtn').style.display='none';}}).catch(console.error);
+    function requestPermission() {
+      if (typeof DeviceOrientationEvent !== 'undefined' && typeof DeviceOrientationEvent.requestPermission === 'function') {
+        DeviceOrientationEvent.requestPermission()
+          .then((state) => {
+            if (state === 'granted') {
+              startOrientation();
+              document.getElementById('permissionBtn').style.display = 'none';
+            }
+          })
+          .catch(console.error);
       }
     }
 
-    function animate(){
+    const clock = new THREE.Clock();
+    const baseCamHeight = 5.0;
+    const currentLookAt = new THREE.Vector3(0, baseCamHeight, -100);
+    const targetLookAt = new THREE.Vector3(0, baseCamHeight, -100);
+    const glanceVector = new THREE.Vector3(0, 0, 0);
+    const glanceTarget = new THREE.Vector3(0, 0, 0);
+    let timeUntilNextGlance = 2.0;
+    let isGlancing = false;
+
+    function hash(n) {
+      return Math.sin(n) * 43758.5453123 - Math.floor(Math.sin(n) * 43758.5453123);
+    }
+
+    function noise(x) {
+      const i = Math.floor(x);
+      const f = x - i;
+      const u = f * f * (3.0 - 2.0 * f);
+      return (1.0 - u) * hash(i) + u * hash(i + 1.0);
+    }
+
+    function animate() {
       requestAnimationFrame(animate);
-      const time=performance.now()*0.001;
-      const delta=time-lastTime;
-      lastTime=time;
-        updateWaterSurface(time);
-        updateRaisedFloor(time);
-        updateExplosions(time);
-        updateFallingTiles(delta);
-        updateKeyboardControls(delta);
-        renderer.render(scene,camera);
+      const dt = clock.getDelta();
+      const totalTime = clock.getElapsedTime();
+
+      terrainUniforms.uTime.value = totalTime;
+      planetUniforms.uTime.value = totalTime;
+      cloudUniforms.uTime.value = totalTime;
+
+      planet.rotation.y = totalTime * 0.05;
+      ring.rotation.z = totalTime * 0.02;
+
+      moon1.position.x = Math.sin(totalTime * 0.1) * 130;
+      moon1.position.z = Math.cos(totalTime * 0.1) * 50;
+
+      moon2.position.x = Math.sin(totalTime * 0.15 + 2.0) * 140;
+      moon2.position.y = Math.cos(totalTime * 0.15) * 40;
+
+      cloudGroup.children.forEach((cloud, index) => {
+        cloud.position.x += Math.sin(totalTime * 0.1 + index) * 0.05;
+        cloud.position.z += 0.05;
+        if (cloud.position.z > 50) cloud.position.z = -300;
+      });
+
+      const walkFreq = 1.5;
+      const t = totalTime * walkFreq;
+      const sway = Math.sin(t) * 0.5;
+      camera.position.x = sway;
+      const bob = -Math.cos(t * 2.0) * 0.35;
+      const heelStrike = Math.sin(t * 2.0 + 0.5) * 0.05;
+      camera.position.y = baseCamHeight + bob + heelStrike;
+
+      const targetRoll = -sway * 0.05;
+      const footPlant = Math.cos(t * 2.0);
+      let pitchShake = 0;
+      if (footPlant > 0.0) pitchShake = Math.pow(footPlant, 2.0) * 0.03;
+
+      timeUntilNextGlance -= dt;
+      if (timeUntilNextGlance <= 0) {
+        if (!isGlancing) {
+          isGlancing = true;
+          const randX = (Math.random() - 0.5) * 80.0;
+          const randY = (Math.random() - 0.2) * 35.0;
+          glanceTarget.set(randX, randY, 0);
+          timeUntilNextGlance = 1.0 + Math.random() * 1.5;
+        } else {
+          isGlancing = false;
+          glanceTarget.set(0, 0, 0);
+          timeUntilNextGlance = 2.0 + Math.random() * 4.0;
+        }
+      }
+      glanceVector.lerp(glanceTarget, 2.0 * dt);
+
+      targetLookAt.set(0, baseCamHeight, -100);
+      targetLookAt.x += sway * 1.5 + glanceVector.x;
+      targetLookAt.y += baseCamHeight + bob * 1.5 + glanceVector.y;
+      currentLookAt.lerp(targetLookAt, 0.08);
+      camera.lookAt(currentLookAt);
+
+      const jitterX = (noise(totalTime * 8.0) - 0.5) * 0.015;
+      const jitterY = (noise(totalTime * 9.0) - 0.5) * 0.015;
+
+      camera.rotation.z += targetRoll;
+      camera.rotation.x += pitchShake + jitterY;
+      camera.rotation.y += jitterX;
+      camera.fov = 60 + Math.sin(t * 2.0) * 0.5;
+      camera.updateProjectionMatrix();
+
+      if (gyroEnabled) {
+        const baseQuat = camera.quaternion.clone();
+        const combinedQuat = baseQuat.multiply(gyroQuat);
+        camera.quaternion.slerp(combinedQuat, 0.2);
       }
 
-    window.addEventListener('load',()=>{
+      composer.render();
+    }
+
+    window.addEventListener('load', () => {
       initScene();
       animate();
-      const btn=document.getElementById('permissionBtn');
-      const calib=document.getElementById('calibrateBtn');
-      calib.addEventListener('click',calibrateOrientation);
-      window.addEventListener('keydown',handleKeyDown);
-      window.addEventListener('keyup',handleKeyUp);
-      if(typeof DeviceOrientationEvent!=='undefined'&&typeof DeviceOrientationEvent.requestPermission==='function'){
-        btn.style.display='block';
-        btn.addEventListener('click',requestPermission);
-      }else{
+      const btn = document.getElementById('permissionBtn');
+      const calib = document.getElementById('calibrateBtn');
+      calib.addEventListener('click', calibrateOrientation);
+      if (typeof DeviceOrientationEvent !== 'undefined' && typeof DeviceOrientationEvent.requestPermission === 'function') {
+        btn.style.display = 'block';
+        btn.addEventListener('click', requestPermission);
+      } else {
         startOrientation();
       }
     });


### PR DESCRIPTION
### Motivation
- Replace the previous grid-room world with a shader-driven surreal walker environment that includes a walking camera effect.
- Preserve mobile gyroscope synchronization (permission flow + calibration) so camera orientation remains responsive on phones.
- Keep the existing navigation UI and overlay while improving visuals with shaders and bloom.
- Provide a more dynamic scene (planet, clouds, animated terrain) driven by GLSL noise.

### Description
- Replaced the old scene code in `game.html` (grid helpers, water, raised floor, explosions, falling tiles) with a new shader-based environment composed of terrain, planet, rings, moons and clouds. 
- Added GLSL `snoise` (2D + 3D) helper and new shader programs for terrain (`terrainVertexShader`/`terrainFragmentShader`), planet, and clouds, plus shader uniforms (`terrainUniforms`, `planetUniforms`, `cloudUniforms`).
- Integrated device-orientation handling and calibration via `requestPermission`, `handleOrientation`, and `calibrateOrientation`, exposed `#permissionBtn`/`#calibrateBtn`, and blend gyro orientation into the walking camera using `gyroQuat`/`gyroEnabled`.
- Added post-processing bloom using `EffectComposer` and `UnrealBloomPass`, and implemented walking camera sway/bob/jitter in the main `animate()` loop to produce the walking effect.

### Testing
- Launched a local HTTP server with `python -m http.server 8000`, which started successfully and served the modified `game.html`.
- Ran a Playwright script that opened `http://127.0.0.1:8000/game.html` and captured a screenshot (`artifacts/game-surreal-walker.png`), which completed successfully.
- No unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654717ea88832aa116a4d1baa9cc61)