### PR TITLE
Point Play Now to terrain demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -380,8 +380,8 @@
         </svg>
       </div>
       <div class="cta-buttons">
-        <a class="play-button" href="game.html">Play Now</a>
-        <a class="secondary" href="terrain.html">Explorer Mode</a>
+        <a class="play-button" href="terrain.html">Play Now</a>
+        <a class="secondary" href="game.html">Neon Flight</a>
         <a class="secondary" href="arena.html">Arena Mode</a>
         <a class="secondary" href="taxi.html">Taxi Assignment</a>
       </div>


### PR DESCRIPTION
### Motivation
- Make the primary CTA open the terrain demo while preserving access to the neon flight scene via a secondary link.

### Description
- Update `index.html` so the `play-button` now links to `terrain.html` and the previous primary link is relabeled `Neon Flight` and links to `game.html`.

### Testing
- Served the site with `python -m http.server` and ran a Playwright script to load `index.html` and capture a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69654a7da3c8832aa2e1f0eec83a0af5)